### PR TITLE
Fixed infra-860, bot did not delete previous comments

### DIFF
--- a/github.go
+++ b/github.go
@@ -395,7 +395,7 @@ func (m *GithubClient) DeletePreviousComments(prNumber string) error {
 	}
 
 	for _, e := range getComments.Repository.PullRequest.Comments.Edges {
-		if e.Node.Author.Login == getComments.Viewer.Login {
+		if cleanBotUserName(e.Node.Author.Login) == cleanBotUserName(getComments.Viewer.Login) {
 			_, err := m.V3.Issues.DeleteComment(context.TODO(), m.Owner, m.Repository, e.Node.DatabaseId)
 			if err != nil {
 				return err
@@ -412,4 +412,11 @@ func parseRepository(s string) (string, string, error) {
 		return "", "", errors.New("malformed repository")
 	}
 	return parts[0], parts[1], nil
+}
+
+func cleanBotUserName(username string) string{
+	if strings.HasSuffix(username, "[bot]"){
+		return strings.TrimSuffix(username, "[bot]")
+	}
+	return username
 }

--- a/github_test.go
+++ b/github_test.go
@@ -1,0 +1,50 @@
+package resource
+
+import "testing"
+
+func Test_cleanBotUserName(t *testing.T) {
+	type args struct {
+		username string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Main Test Case",
+			args: args{
+				username: "infratest[bot]",
+			},
+			want: "infratest",
+		},
+		{
+			name: "Without suffix bot",
+			args: args{
+				username: "infratest",
+			},
+			want: "infratest",
+		},
+		{
+			name: "Bot only",
+			args: args{
+				username: "[bot]",
+			},
+			want: "",
+		},
+		{
+			name: "Bot at start",
+			args: args{
+				username: "[bot]infratest",
+			},
+			want: "[bot]infratest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cleanBotUserName(tt.args.username); got != tt.want {
+				t.Errorf("cleanBotUserName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
See my comments on the original forked repo:
https://github.com/telia-oss/github-pr-resource/issues/245#issuecomment-820357684
Copied below:

Hey 👋🏻  

I had a similar issue, specifically:
* My user was a GitHub Bot App
* It didn't delete comments
* Using OAuth on a personal account it did.
The issue occurs here:

https://github.com/telia-oss/github-pr-resource/blob/9ec47e2d9f28d13a4738ff48f2f40d2a570b251a/github.go#L398

When evaluating, it comes out to:

```diff
+ if "githubApp" == "githubApp[bot]"
- if e.Node.Author.Login == getComments.Viewer.Login {
```

Specifically, `getComments.Viewer.Login` returns the name with `[bot]` but `e.Node.Author.Login` returns it without bot.

We fixed this with an if statement checking for bots :-)

https://mondough.atlassian.net/secure/RapidBoard.jspa?rapidView=411&modal=detail&selectedIssue=INFRA-860