### PR TITLE
Fixed infra-860, bot did not delete previous comments

### DIFF
--- a/check.go
+++ b/check.go
@@ -20,7 +20,7 @@ func Check(request CheckRequest, manager Github) (CheckResponse, error) {
 		filterStates = request.Source.States
 	}
 
-	pulls, err := manager.ListPullRequests(filterStates)
+	pulls, err := manager.ListPullRequests(filterStates, request.Source.Branch)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get last commits: %s", err)
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -91,6 +91,19 @@ func TestCheckE2E(t *testing.T) {
 		},
 
 		{
+			description: "check will only return versions that match the specified branch",
+			source: resource.Source{
+				Repository:  "itsdalmo/test-repository",
+				AccessToken: os.Getenv("GITHUB_ACCESS_TOKEN"),
+				Branch:      "my_second_pull",
+			},
+			version: resource.Version{},
+			expected: resource.CheckResponse{
+				resource.Version{PR: targetPullRequestID, Commit: targetCommitID, CommittedDate: targetDateTime},
+			},
+		},
+
+		{
 			description: "check will skip versions which only match the ignore paths",
 			source: resource.Source{
 				Repository:  "itsdalmo/test-repository",

--- a/fakes/fake_github.go
+++ b/fakes/fake_github.go
@@ -61,10 +61,11 @@ type FakeGithub struct {
 		result1 []string
 		result2 error
 	}
-	ListPullRequestsStub        func([]githubv4.PullRequestState) ([]*resource.PullRequest, error)
+	ListPullRequestsStub        func([]githubv4.PullRequestState, string) ([]*resource.PullRequest, error)
 	listPullRequestsMutex       sync.RWMutex
 	listPullRequestsArgsForCall []struct {
 		arg1 []githubv4.PullRequestState
+		arg2 string
 	}
 	listPullRequestsReturns struct {
 		result1 []*resource.PullRequest
@@ -357,7 +358,7 @@ func (fake *FakeGithub) ListModifiedFilesReturnsOnCall(i int, result1 []string, 
 	}{result1, result2}
 }
 
-func (fake *FakeGithub) ListPullRequests(arg1 []githubv4.PullRequestState) ([]*resource.PullRequest, error) {
+func (fake *FakeGithub) ListPullRequests(arg1 []githubv4.PullRequestState, arg2 string) ([]*resource.PullRequest, error) {
 	var arg1Copy []githubv4.PullRequestState
 	if arg1 != nil {
 		arg1Copy = make([]githubv4.PullRequestState, len(arg1))
@@ -367,11 +368,12 @@ func (fake *FakeGithub) ListPullRequests(arg1 []githubv4.PullRequestState) ([]*r
 	ret, specificReturn := fake.listPullRequestsReturnsOnCall[len(fake.listPullRequestsArgsForCall)]
 	fake.listPullRequestsArgsForCall = append(fake.listPullRequestsArgsForCall, struct {
 		arg1 []githubv4.PullRequestState
-	}{arg1Copy})
-	fake.recordInvocation("ListPullRequests", []interface{}{arg1Copy})
+		arg2 string
+	}{arg1Copy, arg2})
+	fake.recordInvocation("ListPullRequests", []interface{}{arg1Copy, arg2})
 	fake.listPullRequestsMutex.Unlock()
 	if fake.ListPullRequestsStub != nil {
-		return fake.ListPullRequestsStub(arg1)
+		return fake.ListPullRequestsStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -386,17 +388,17 @@ func (fake *FakeGithub) ListPullRequestsCallCount() int {
 	return len(fake.listPullRequestsArgsForCall)
 }
 
-func (fake *FakeGithub) ListPullRequestsCalls(stub func([]githubv4.PullRequestState) ([]*resource.PullRequest, error)) {
+func (fake *FakeGithub) ListPullRequestsCalls(stub func([]githubv4.PullRequestState, string) ([]*resource.PullRequest, error)) {
 	fake.listPullRequestsMutex.Lock()
 	defer fake.listPullRequestsMutex.Unlock()
 	fake.ListPullRequestsStub = stub
 }
 
-func (fake *FakeGithub) ListPullRequestsArgsForCall(i int) []githubv4.PullRequestState {
+func (fake *FakeGithub) ListPullRequestsArgsForCall(i int) ([]githubv4.PullRequestState, string) {
 	fake.listPullRequestsMutex.RLock()
 	defer fake.listPullRequestsMutex.RUnlock()
 	argsForCall := fake.listPullRequestsArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeGithub) ListPullRequestsReturns(result1 []*resource.PullRequest, result2 error) {

--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type Source struct {
 	RequiredReviewApprovals int                         `json:"required_review_approvals"`
 	Labels                  []string                    `json:"labels"`
 	States                  []githubv4.PullRequestState `json:"states"`
+	Branch                  string                      `json:"branch"`
 }
 
 // Validate the source configuration.


### PR DESCRIPTION
**Approved in https://github.com/monzo/github-pr-resource/pull/2**

See my comments on the original forked repo:
https://github.com/telia-oss/github-pr-resource/issues/245#issuecomment-820357684
Copied below:

Hey 👋🏻  

I had a similar issue, specifically:
* My user was a GitHub Bot App
* It didn't delete comments
* Using OAuth on a personal account it did.
The issue occurs here:

https://github.com/telia-oss/github-pr-resource/blob/9ec47e2d9f28d13a4738ff48f2f40d2a570b251a/github.go#L398

When evaluating, it comes out to:

```diff
+ if "githubApp" == "githubApp[bot]"
- if e.Node.Author.Login == getComments.Viewer.Login {
```

Specifically, `getComments.Viewer.Login` returns the name with `[bot]` but `e.Node.Author.Login` returns it without bot.

We fixed this with an if statement checking for bots :-)

https://mondough.atlassian.net/secure/RapidBoard.jspa?rapidView=411&modal=detail&selectedIssue=INFRA-860