### PR TITLE
Add updated_in_the_last option to consider only PRs updated recently

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Make sure to check out [#migrating](#migrating) to learn more.
 | `labels`                    | No       | `["bug", "enhancement"]`         | The labels on the PR. The pipeline will only trigger on pull requests having at least one of the specified labels.                                                                                                                                                                         |
 | `disable_git_lfs`           | No       | `true`                           | Disable Git LFS, skipping an attempt to convert pointers of files tracked into their corresponding objects when checked out into a working copy.                                                                                                                                           |
 | `states`                    | No       | `["OPEN", "MERGED"]`             | The PR states to select (`OPEN`, `MERGED` or `CLOSED`). The pipeline will only trigger on pull requests matching one of the specified states. Default is ["OPEN"].                                                                                                                         |
+| `updated_in_the_last`       | No       | `1h`                             | Check the PRs that were updated in the last amount of time set here, for example `1h`, `24h`, `1d`, `30m`.                                                                                                                         |
 
 Notes:
  - If `v3_endpoint` is set, `v4_endpoint` must also be set (and the other way around).

--- a/check.go
+++ b/check.go
@@ -2,10 +2,12 @@ package resource
 
 import (
 	"fmt"
+	"log"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/shurcooL/githubv4"
 )
@@ -19,14 +21,28 @@ func Check(request CheckRequest, manager Github) (CheckResponse, error) {
 	if len(request.Source.States) > 0 {
 		filterStates = request.Source.States
 	}
+	log.Printf("Filtering for states: %v", filterStates)
 
-	pulls, err := manager.ListPullRequests(filterStates)
+	var prUpdatedAfterTime *time.Time
+	if request.Source.UpdatedInTheLast != "" {
+		duration, err := time.ParseDuration(request.Source.UpdatedInTheLast)
+		if err == nil {
+			updatedInTheLastTime := time.Now().Add(-duration)
+			prUpdatedAfterTime = &updatedInTheLastTime
+			log.Printf("Filtering PRs updated since %v", prUpdatedAfterTime)
+		} else {
+			log.Printf("Error parsing updated_in_the_last field: %v", err)
+		}
+	}
+
+	pulls, err := manager.ListPullRequests(filterStates, prUpdatedAfterTime)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get last commits: %s", err)
 	}
 
 	disableSkipCI := request.Source.DisableCISkip
 
+	log.Printf("Processing pull requests")
 Loop:
 	for _, p := range pulls {
 		// [ci skip]/[skip ci] in Pull request title

--- a/github.go
+++ b/github.go
@@ -5,12 +5,14 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v28/github"
 	"github.com/shurcooL/githubv4"
@@ -20,7 +22,7 @@ import (
 // Github for testing purposes.
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -o fakes/fake_github.go . Github
 type Github interface {
-	ListPullRequests([]githubv4.PullRequestState) ([]*PullRequest, error)
+	ListPullRequests([]githubv4.PullRequestState, *time.Time) ([]*PullRequest, error)
 	ListModifiedFiles(int) ([]string, error)
 	PostComment(string, string) error
 	GetPullRequest(string, string) (*PullRequest, error)
@@ -98,7 +100,7 @@ func NewGithubClient(s *Source) (*GithubClient, error) {
 }
 
 // ListPullRequests gets the last commit on all pull requests with the matching state.
-func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState) ([]*PullRequest, error) {
+func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState, prUpdatedAfterTime *time.Time) ([]*PullRequest, error) {
 	var query struct {
 		Repository struct {
 			PullRequests struct {
@@ -128,7 +130,7 @@ func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState) ([
 					EndCursor   githubv4.String
 					HasNextPage bool
 				}
-			} `graphql:"pullRequests(first:$prFirst,states:$prStates,after:$prCursor)"`
+			} `graphql:"pullRequests(first:$prFirst,states:$prStates,after:$prCursor,orderBy:$prOrderBy)"`
 		} `graphql:"repository(owner:$repositoryOwner,name:$repositoryName)"`
 	}
 
@@ -143,7 +145,24 @@ func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState) ([
 		"labelsFirst":     githubv4.Int(100),
 	}
 
+	if prUpdatedAfterTime != nil {
+		// We're interested in the most recent PRs, doing this to avoid
+		// many calls to Github API
+		vars["prOrderBy"] = githubv4.IssueOrder{
+			Field:     githubv4.IssueOrderFieldUpdatedAt,
+			Direction: githubv4.OrderDirectionDesc,
+		}
+	} else {
+		// This is the default sorting
+		vars["prOrderBy"] = githubv4.IssueOrder{
+			Field:     githubv4.IssueOrderFieldCreatedAt,
+			Direction: githubv4.OrderDirectionAsc,
+		}
+	}
+
 	var response []*PullRequest
+	log.Printf("Listing pull requests...")
+	foundAllPRs := false
 	for {
 		if err := m.V4.Query(context.TODO(), &query, vars); err != nil {
 			return nil, err
@@ -153,7 +172,12 @@ func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState) ([
 			for _, l := range p.Node.Labels.Edges {
 				labels = append(labels, l.Node.LabelObject)
 			}
-
+			if prUpdatedAfterTime != nil {
+				if p.Node.PullRequestObject.UpdatedAt.Time.Before(*prUpdatedAfterTime) {
+					foundAllPRs = true
+					break
+				}
+			}
 			for _, c := range p.Node.Commits.Edges {
 				response = append(response, &PullRequest{
 					PullRequestObject:   p.Node.PullRequestObject,
@@ -163,11 +187,14 @@ func (m *GithubClient) ListPullRequests(prStates []githubv4.PullRequestState) ([
 				})
 			}
 		}
-		if !query.Repository.PullRequests.PageInfo.HasNextPage {
+		if !query.Repository.PullRequests.PageInfo.HasNextPage || foundAllPRs {
 			break
+		} else {
+			log.Printf("Found %v pull requests so far", len(response))
 		}
 		vars["prCursor"] = query.Repository.PullRequests.PageInfo.EndCursor
 	}
+	log.Printf("Found %v pull requests", len(response))
 	return response, nil
 }
 

--- a/models.go
+++ b/models.go
@@ -27,6 +27,7 @@ type Source struct {
 	RequiredReviewApprovals int                         `json:"required_review_approvals"`
 	Labels                  []string                    `json:"labels"`
 	States                  []githubv4.PullRequestState `json:"states"`
+	UpdatedInTheLast        string                      `json:"updated_in_the_last"`
 }
 
 // Validate the source configuration.
@@ -114,6 +115,8 @@ type PullRequestObject struct {
 	State             githubv4.PullRequestState
 	ClosedAt          githubv4.DateTime
 	MergedAt          githubv4.DateTime
+	CreatedAt         githubv4.DateTime
+	UpdatedAt         githubv4.DateTime
 }
 
 // UpdatedDate returns the last time a PR was updated, either by commit


### PR DESCRIPTION
The PR adds a new option `updated_in_the_last` so that the check will only consider PRs updated recently.

This feature is very useful when Concourse is polling for changes and speeds up the check by ignoring the PRs that are older than the duration set.

It also adds some extra log lines that are useful to better understand what is happening.