### PR TITLE
Update Taskfile version to 3

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 vars:
   BUILD_DIR: build


### PR DESCRIPTION
Currently the build fails because the version of the Taskfile is old (v2). You can check this locally with `docker build .` as well.

This PR updates the version string in the Taskfile to `3`