### PR TITLE
Add logging to comment posting path

### DIFF
--- a/github.go
+++ b/github.go
@@ -279,7 +279,7 @@ func (m *GithubClient) PostComment(prNumber, comment string) error {
 		return fmt.Errorf("failed to convert pull request number to int: %s", err)
 	}
 
-	_, _, err = m.V3.Issues.CreateComment(
+	created, resp, err := m.V3.Issues.CreateComment(
 		context.TODO(),
 		m.Owner,
 		m.Repository,
@@ -288,7 +288,11 @@ func (m *GithubClient) PostComment(prNumber, comment string) error {
 			Body: github.String(comment),
 		},
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	log.Printf("Posted comment to %s/%s#%d: comment ID %d, API status %s", m.Owner, m.Repository, pr, created.GetID(), resp.Status)
+	return nil
 }
 
 // GetChangedFiles ...

--- a/github.go
+++ b/github.go
@@ -417,7 +417,7 @@ func (m *GithubClient) UpdateCommitStatus(commitRef, baseContext, statusContext,
 		description = fmt.Sprintf("Concourse CI build %s", status)
 	}
 
-	_, _, err := m.V3.Repositories.CreateStatus(
+	_, resp, err := m.V3.Repositories.CreateStatus(
 		context.TODO(),
 		m.Owner,
 		m.Repository,
@@ -429,7 +429,11 @@ func (m *GithubClient) UpdateCommitStatus(commitRef, baseContext, statusContext,
 			Context:     github.String(path.Join(baseContext, statusContext)),
 		},
 	)
-	return err
+	if err != nil {
+		return err
+	}
+	log.Printf("Set commit status on %s/%s@%.7s: %s (%s/%s), API status %s", m.Owner, m.Repository, commitRef, status, baseContext, statusContext, resp.Status)
+	return nil
 }
 
 func (m *GithubClient) DeletePreviousComments(prNumber string) error {
@@ -470,15 +474,18 @@ func (m *GithubClient) DeletePreviousComments(prNumber string) error {
 		return err
 	}
 
+	deleted := 0
 	for _, e := range getComments.Repository.PullRequest.Comments.Edges {
 		if cleanBotUserName(e.Node.Author.Login) == cleanBotUserName(getComments.Viewer.Login) {
 			_, err := m.V3.Issues.DeleteComment(context.TODO(), m.Owner, m.Repository, e.Node.DatabaseId)
 			if err != nil {
 				return err
 			}
+			deleted++
 		}
 	}
 
+	log.Printf("Deleted %d previous comments on %s/%s#%d", deleted, m.Owner, m.Repository, pr)
 	return nil
 }
 

--- a/out.go
+++ b/out.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,10 +79,13 @@ func Put(request PutRequest, manager Github, inputDir string) (*PutResponse, err
 		}
 		comment := string(content)
 		if comment != "" {
+			log.Printf("Posting comment to PR #%s (%d bytes)", version.PR, len(comment))
 			err = manager.PostComment(version.PR, safeExpandEnv(comment))
 			if err != nil {
 				return nil, fmt.Errorf("failed to post comment: %s", err)
 			}
+		} else {
+			log.Printf("Skipping comment for PR #%s: comment file %q was empty", version.PR, p.CommentFile)
 		}
 	}
 

--- a/out.go
+++ b/out.go
@@ -50,6 +50,7 @@ func Put(request PutRequest, manager Github, inputDir string) (*PutResponse, err
 			description = string(content)
 		}
 
+		log.Printf("Setting commit status on PR #%s: %s", version.PR, p.Status)
 		if err := manager.UpdateCommitStatus(version.Commit, p.BaseContext, safeExpandEnv(p.Context), p.Status, safeExpandEnv(p.TargetURL), description); err != nil {
 			return nil, fmt.Errorf("failed to set status: %s", err)
 		}
@@ -57,6 +58,7 @@ func Put(request PutRequest, manager Github, inputDir string) (*PutResponse, err
 
 	// Delete previous comments if specified
 	if request.Params.DeletePreviousComments {
+		log.Printf("Deleting previous comments on PR #%s", version.PR)
 		err = manager.DeletePreviousComments(version.PR)
 		if err != nil {
 			return nil, fmt.Errorf("failed to delete previous comments: %s", err)
@@ -65,6 +67,7 @@ func Put(request PutRequest, manager Github, inputDir string) (*PutResponse, err
 
 	// Set comment if specified
 	if p := request.Params; p.Comment != "" {
+		log.Printf("Posting inline comment to PR #%s (%d bytes)", version.PR, len(p.Comment))
 		err = manager.PostComment(version.PR, safeExpandEnv(p.Comment))
 		if err != nil {
 			return nil, fmt.Errorf("failed to post comment: %s", err)


### PR DESCRIPTION
The `put` step for posting PR comments currently has zero logging — if a comment silently fails to appear on GitHub, there's no way to diagnose what happened from the build output.

This adds `log.Printf` calls (which write to stderr, shown in Concourse step output) to the comment-posting code path:

- Logs when a comment is about to be posted, with PR number and content size
- Logs the GitHub API response: comment ID and HTTP status code
- Logs when a comment file was empty and the post was skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)